### PR TITLE
Hotfix

### DIFF
--- a/experiments/main.py
+++ b/experiments/main.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 import matplotlib.pyplot as plt
 from openai import OpenAI
 import pandas as pd  # type: ignore[import-untyped]
+import torch
 import tqdm  # type: ignore[import-untyped]
 from transformers.models.t5.modeling_t5 import T5ForConditionalGeneration
 from transformers.models.t5.tokenization_t5_fast import T5TokenizerFast
@@ -24,7 +25,6 @@ from simulator_alignment.simulators.monot5 import MonoT5Simulator
 from simulator_alignment.simulators.olz import OlzGPT4o
 from simulator_alignment.simulators.trema import TREMA4Prompts, TREMASumDecompose
 from simulator_alignment.simulators.william import WilliamUmbrela1, WilliamUmbrelaGPT4oMini
-import torch
 
 logger = logging.getLogger(__name__)
 
@@ -164,10 +164,10 @@ if __name__ == "__main__":
     openai_engine = OpenAI()
     vllm_engine = LLM(model="meta-llama/Meta-Llama-3-8B-Instruct")
 
-    monoT5_model = T5ForConditionalGeneration.from_pretrained(
-        "castorini/monot5-base-msmarco-10k"
-    )
-    monoT5_model = monoT5_model.to("cuda" if torch.cuda.is_available() else "cpu")
+    monoT5_model = T5ForConditionalGeneration.from_pretrained("castorini/monot5-base-msmarco-10k")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logger.info(f"Using device: {device}")
+    monoT5_model = monoT5_model.to(device)
     monoT5_tokenizer = T5TokenizerFast.from_pretrained("castorini/monot5-base-msmarco-10k")
 
     simulators: list[BaseSimulator] = [

--- a/experiments/main.py
+++ b/experiments/main.py
@@ -24,6 +24,7 @@ from simulator_alignment.simulators.monot5 import MonoT5Simulator
 from simulator_alignment.simulators.olz import OlzGPT4o
 from simulator_alignment.simulators.trema import TREMA4Prompts, TREMASumDecompose
 from simulator_alignment.simulators.william import WilliamUmbrela1, WilliamUmbrelaGPT4oMini
+import torch
 
 logger = logging.getLogger(__name__)
 
@@ -164,9 +165,9 @@ if __name__ == "__main__":
     vllm_engine = LLM(model="meta-llama/Meta-Llama-3-8B-Instruct")
 
     monoT5_model = T5ForConditionalGeneration.from_pretrained(
-        "castorini/monot5-base-msmarco-10k", device_map="auto", torch_dtype="auto"
+        "castorini/monot5-base-msmarco-10k"
     )
-    monoT5_model.device("cuda:1")
+    monoT5_model = monoT5_model.to("cuda" if torch.cuda.is_available() else "cpu")
     monoT5_tokenizer = T5TokenizerFast.from_pretrained("castorini/monot5-base-msmarco-10k")
 
     simulators: list[BaseSimulator] = [

--- a/simulator_alignment/simulators/dummy.py
+++ b/simulator_alignment/simulators/dummy.py
@@ -35,3 +35,39 @@ class RandomAssessor(BaseSimulator):
     @property
     def name(self) -> str:
         return f"{self.__class__.__name__}_{self.min_val}_{self.max_val}"
+
+
+class NoisyCopyCatAssessor(BaseSimulator):
+    """Dummy assessor that predicts relevance such that
+    for each sample, with probability self.noise_probability
+    assign a random incorrect relevance in [0..max_score], else
+    assign the ground‑truth relevance.
+    """
+
+    def __init__(self, noise_probability: float, max_score: int = 3) -> None:
+        """Creates a NoisyCopyCatAssessor instance.
+
+        Args:
+            noise_probability (float): A probability indicating
+                how often the assessor is likely to be wrong about a judgement
+            max_score (int): The maximum score a sample can have as its
+                relevance assessment.
+        """
+        self.noise_probability = noise_probability
+        self.max_score = max_score
+        self._other_scores: dict[int, list[int]] = {
+            gt: [s for s in range(max_score + 1) if s != gt] for gt in range(max_score + 1)
+        }
+
+    def _score_samples(self, samples: list[Sample]) -> list[Sample]:
+        for sample in samples:
+            if random.random() <= self.noise_probability:
+                alt_scores = self._other_scores[sample.groundtruth_relevance]
+                sample.set_predicted_relevance(random.choice(alt_scores))
+            else:
+                sample.set_predicted_relevance(sample.groundtruth_relevance)
+        return samples
+
+    @property
+    def name(self) -> str:
+        return f"{self.__class__.__name__}_{self.noise_probability}"


### PR DESCRIPTION
## Summary by Sourcery

Add a noisy copy-cat assessor simulator and update device handling for MonoT5 model

New Features:
- Introduce NoisyCopyCatAssessor simulator that can randomly modify sample relevance with a configurable noise probability

Enhancements:
- Improve device selection for MonoT5 model to support both CUDA and CPU environments